### PR TITLE
Refactor test logic into Validator api

### DIFF
--- a/generic/src/test/java/org/jboss/pvt/generic/EAPJarsPresentInRepoTest.java
+++ b/generic/src/test/java/org/jboss/pvt/generic/EAPJarsPresentInRepoTest.java
@@ -16,31 +16,37 @@
 
 package org.jboss.pvt.generic;
 
-import org.jboss.pvt.harness.AbstractProductJarsPresentInRepo;
-import org.junit.Ignore;
+import org.jboss.pvt.harness.ProductJarsPresentInRepo;
+import org.jboss.pvt.harness.exception.PVTException;
+import org.jboss.pvt.harness.rules.ParameterHandler;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.File;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by yyang on 7/11/16.
  */
-@Ignore //TODO : Remove Junit categories and make test generic.
 @Category({EAP7.class, EAP6.class})
-public class EAPJarsPresentInRepoTest extends AbstractProductJarsPresentInRepo{
+public class EAPJarsPresentInRepoTest
+{
+    @ClassRule
+    public static final ParameterHandler parameterHandler = new ParameterHandler();
 
-    @Override
-    protected File getRepoDir() {
-        return new File(EAP7TestSuite.getTestConfig().getRepoDir());
+    private ProductJarsPresentInRepo pjp = new ProductJarsPresentInRepo( parameterHandler );
+
+    @Before
+    public void setupBefore()
+    {
+        // TODO: Should possibly come from a config file?
+        pjp.initialiseFilter(new String[]{"jboss-modules.jar", "jboss-cli-client.jar", "launcher.jar", "jboss-client.jar", "jboss-seam-int.jar", "-jandex.jar"} );
     }
 
-    @Override
-    protected File getProductDir() {
-        return new File(EAP7TestSuite.getTestConfig().getEapDir());
-    }
-
-    @Override
-    protected String[] getJarIgnoreFilter() {
-        return new String[]{"jboss-modules.jar", "jboss-cli-client.jar", "launcher.jar", "jboss-client.jar", "jboss-seam-int.jar", "-jandex.jar"};
+    @Test
+    public void test1() throws PVTException
+    {
+        assertTrue ( pjp.validate() );
     }
 }

--- a/harness/src/main/java/org/jboss/pvt/harness/AbstractJarDigestSignTest.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/AbstractJarDigestSignTest.java
@@ -70,6 +70,7 @@ public abstract class AbstractJarDigestSignTest {
             }
         }
 
+
         Assert.assertTrue(signed == mustSigned());
     }
 

--- a/harness/src/main/java/org/jboss/pvt/harness/ProductJarsPresentInRepo.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/ProductJarsPresentInRepo.java
@@ -16,38 +16,57 @@
 
 package org.jboss.pvt.harness;
 
+import org.jboss.pvt.harness.exception.PVTException;
+import org.jboss.pvt.harness.exception.PVTSystemException;
+import org.jboss.pvt.harness.rules.ParameterHandler;
 import org.jboss.pvt.harness.utils.DirUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.jboss.pvt.harness.validators.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 /**
  * Created by yyang on 7/27/16.
+ *
+ * TODO: Add description of the test
  */
-public abstract class AbstractProductJarsPresentInRepo {
+public final class ProductJarsPresentInRepo extends Validator<File>
+{
     //Ref: https://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/EAP7/view/EAP7-Prod/job/jboss-eap-7.0.x-handoff-repository-maven-check-EAP-jars-in-repo/
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    @Test
-    public void testProductJarsPresentInRepo() {
+    private String[] filters = new String[]{};
+
+    public ProductJarsPresentInRepo( ParameterHandler handler)
+    {
+        super( handler );
+    }
+
+
+    /**
+     * Validation logic that should be applied.
+     * @return true if it validates successfully.
+     * @throws PVTException if an error occurs.
+     */
+    @Override
+    public boolean validate() throws PVTException
+    {
+        boolean success = false;
 
         List<File> notPresentJars = new ArrayList<File>();
 
-        Collection<File> productJars =  DirUtils.listFilesRecursively( getProductDir(), new FileFilter() {
+        Collection<File> productJars =  DirUtils.listFilesRecursively( getParameterHandler().getDistributionDirectory(), new FileFilter() {
             public boolean accept(File pathname) {
                 return pathname.isFile() && pathname.getName().endsWith(".jar");
             }
         });
 
-        Collection<File> repoJars =  DirUtils.listFilesRecursively(getRepoDir(), new FileFilter() {
+        Collection<File> repoJars =  DirUtils.listFilesRecursively(getParameterHandler().getRepositoryDirectory(), new FileFilter() {
             public boolean accept(File pathname) {
                 return pathname.isFile() && pathname.getName().endsWith(".jar");
             }
@@ -55,7 +74,7 @@ public abstract class AbstractProductJarsPresentInRepo {
 
 
         for(File productJar : productJars) {
-            if(ignoreCheck(productJar)){
+            if( filter( productJar)){
                 logger.info("Ignore jar: " + productJar);
                 continue;
             }
@@ -71,26 +90,34 @@ public abstract class AbstractProductJarsPresentInRepo {
                 notPresentJars.add(productJar);
             }
         }
-        if(!notPresentJars.isEmpty()) {
-            logger.debug("Not present jars: " + Arrays.toString(notPresentJars.toArray()));
-            Assert.assertTrue(false);
+        if(notPresentJars.isEmpty()) {
+            success = true;
         }
+        return success;
     }
 
-    protected boolean ignoreCheck(File file) {
-        for(String filter : getJarIgnoreFilter()) {
-            if(file.getPath().contains(filter)) {
+    /**
+     * Apply a set of filters to a validator
+     * // TODO : Define api here.
+     */
+    @Override
+    public boolean filter( File... file) {
+        if ( file.length != 1 )
+        {
+            throw new PVTSystemException( "Unexpected length of arguments for this filter" );
+        }
+        for(String filter : filters) {
+            if(file[0].getPath().contains(filter)) {
                 return true;
             }
         }
         return false;
     }
 
-    protected String[] getJarIgnoreFilter() {
-        return new String[]{};
+    @Override
+    public void initialiseFilter(String[] filters)
+    {
+        this.filters = filters;
     }
-
-    protected abstract File getRepoDir();
-    protected abstract File getProductDir();
 
 }

--- a/harness/src/main/java/org/jboss/pvt/harness/RepositoryBomsTest.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/RepositoryBomsTest.java
@@ -19,6 +19,7 @@ package org.jboss.pvt.harness;
 /**
  * Created by yyang on 7/27/16.
  */
-public abstract class AbstractRepositoryBomsTest {
+public class RepositoryBomsTest
+{
     //TODO: https://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/EAP7/view/EAP7-Prod/job/jboss-eap-7.0.x-handoff-check-eap-maven-repository-boms/
 }

--- a/harness/src/main/java/org/jboss/pvt/harness/exception/PVTException.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/exception/PVTException.java
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package org.jboss.pvt.harness;
+package org.jboss.pvt.harness.exception;
 
 /**
- * Created by rnc on 28/07/16.
+ * Created by rnc on 29/07/16.
  */
-public enum ProductSupport
+public class PVTException extends Exception
 {
-    AMQ,
-    EAP,
-    BRMS,
-    ALL
+    public PVTException( String s )
+    {
+        super (s);
+    }
+
+    public PVTException( String s, Exception e )
+    {
+        super (s, e);
+    }
 }

--- a/harness/src/main/java/org/jboss/pvt/harness/exception/PVTSystemException.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/exception/PVTSystemException.java
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-package org.jboss.pvt.harness;
-
-import java.io.FileNotFoundException;
+package org.jboss.pvt.harness.exception;
 
 /**
  * Created by rnc on 29/07/16.
  */
-public class PVTException extends RuntimeException
+public class PVTSystemException
+                extends RuntimeException
 {
-    public PVTException( String s )
+    public PVTSystemException( String s )
     {
         super (s);
     }
 
-    public PVTException( String s, Exception e )
+    public PVTSystemException( String s, Exception e )
     {
         super (s, e);
     }

--- a/harness/src/main/java/org/jboss/pvt/harness/rules/ParameterHandler.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/rules/ParameterHandler.java
@@ -17,8 +17,8 @@
 package org.jboss.pvt.harness.rules;
 
 import org.apache.commons.io.FileUtils;
-import org.jboss.pvt.harness.PVTException;
-import org.jboss.pvt.harness.ProductSupport;
+import org.jboss.pvt.harness.exception.PVTException;
+import org.jboss.pvt.harness.utils.ProductSupport;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,10 +41,10 @@ public class ParameterHandler extends ExternalResource
     private File distributionZip;
 
     @Override
-    protected void before ()
+    protected void before () throws Exception
     {
         distribution = System.getProperty( "DISTRIBUTION_ZIP" );
-        mavenRepo = System.getProperty( "MAVEN_REPO_ZIP" );
+        mavenRepo = System.getProperty( "MAVEN_REPO_ZIP", "" );
         product = ProductSupport.valueOf( System.getProperty( "PRODUCT", "ALL" ) );
 
         logger.debug( "Established distribution {}, maven repository {}, and product of {}", distribution, mavenRepo, product );
@@ -63,7 +63,17 @@ public class ParameterHandler extends ExternalResource
         return distributionZip;
     }
 
-    private void downloadZips()
+    public File getDistributionDirectory()
+    {
+        return distributionZip;
+    }
+
+    public File getRepositoryDirectory()
+    {
+        return new File (mavenRepo); // TODO: Implement repository and distribution zip handling and unzipped.
+    }
+
+    private void downloadZips() throws PVTException
     {
         if ( distributionZip != null && distributionZip.exists() )
         {

--- a/harness/src/main/java/org/jboss/pvt/harness/utils/ClassVersion.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/utils/ClassVersion.java
@@ -1,0 +1,41 @@
+package org.jboss.pvt.harness.utils;
+
+import org.jboss.pvt.harness.exception.PVTException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by rnc on 30/07/16.
+ */
+public enum ClassVersion
+{
+    JAVA_12( 46 ), JAVA_13( 47 ), JAVA_14( 48 ), JAVA_15( 49 ), JAVA_16( 50 ), JAVA_17( 51 ), JAVA_18( 52 );
+
+    private static Map<Integer, ClassVersion> map = new HashMap<>();
+
+    static
+    {
+        for ( ClassVersion cv : ClassVersion.values() )
+        {
+            map.put( cv.byteValue, cv );
+        }
+    }
+
+    private int byteValue;
+
+    ClassVersion( int value )
+    {
+        this.byteValue = value;
+    }
+
+    public static ClassVersion parseInt( int value ) throws PVTException
+    {
+        ClassVersion result = map.get( value );
+        if ( result == null )
+        {
+            throw new PVTException( "Class version type not found for " + value );
+        }
+        return result;
+    }
+}

--- a/harness/src/main/java/org/jboss/pvt/harness/utils/ClassVersionInspector.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/utils/ClassVersionInspector.java
@@ -1,5 +1,6 @@
-package org.jboss.pvt.harness;
+package org.jboss.pvt.harness.utils;
 
+import org.jboss.pvt.harness.exception.PVTException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -21,45 +20,12 @@ public class ClassVersionInspector
 {
     private static Logger logger = LoggerFactory.getLogger( ClassVersionInspector.class );
 
-    public enum ClassVersion
-    {
-        JAVA_12(46),
-        JAVA_13(47),
-        JAVA_14(48),
-        JAVA_15(49),
-        JAVA_16(50),
-        JAVA_17(51),
-        JAVA_18(52);
-
-        private static Map<Integer, ClassVersion> map = new HashMap<>();
-        static
-        {
-            for ( ClassVersion cv : ClassVersion.values() )
-            {
-                map.put( cv.byteValue, cv );
-            }
-        }
-
-        private int byteValue;
-
-        ClassVersion( int value )
-        {
-            this.byteValue = value;
-        }
-
-        public static ClassVersion parseInt (int value)
-        {
-            ClassVersion result = map.get( value );
-            if ( result == null )
-            {
-                throw new PVTException( "Class version type not found for " + value );
-            }
-            return result;
-        }
-    }
-
-
-    public static ClassVersion checkClassVersion (String filename)
+    /**
+     * Takes a Class filename and returns the ClassVersion.
+     * @param filename valid class filename to check
+     * @return ClassVersion of class.
+     */
+    public static ClassVersion checkClassVersion (String filename) throws PVTException
     {
         FileInputStream in;
         try
@@ -74,7 +40,7 @@ public class ClassVersionInspector
         return checkClassVersion( in );
     }
 
-    private static ClassVersion checkClassVersion (InputStream filename)
+    private static ClassVersion checkClassVersion (InputStream filename) throws PVTException
     {
         DataInputStream in = new DataInputStream( filename );
 
@@ -106,7 +72,7 @@ public class ClassVersionInspector
         }
     }
 
-    public static boolean checkJarVersion (String filename, ClassVersion version)
+    public static boolean checkJarVersion (String filename, ClassVersion version) throws PVTException
     {
         JarFile jar;
         try

--- a/harness/src/main/java/org/jboss/pvt/harness/utils/ProductSupport.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/utils/ProductSupport.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pvt.harness.utils;
+
+/**
+ * Created by rnc on 28/07/16.
+ *
+ * TODO: Consider replacing by configuration file
+ */
+public enum ProductSupport
+{
+    AMQ,
+    EAP,
+    BRMS,
+    ALL
+}

--- a/harness/src/main/java/org/jboss/pvt/harness/validators/Validator.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/validators/Validator.java
@@ -1,0 +1,46 @@
+package org.jboss.pvt.harness.validators;
+
+import org.jboss.pvt.harness.exception.PVTException;
+import org.jboss.pvt.harness.exception.PVTSystemException;
+import org.jboss.pvt.harness.rules.ParameterHandler;
+
+/**
+ * Created by rnc on 02/08/16.
+ */
+public abstract class Validator<T>
+{
+    private ParameterHandler handler;
+
+    public Validator (ParameterHandler handler)
+    {
+        this.handler = handler;
+    }
+
+    /**
+     * Validation logic that should be applied.
+     * @return true if it validates successfully.
+     * @throws PVTException if an error occurs.
+     */
+    public abstract boolean validate() throws PVTException;
+
+    /**
+     * @return return the current ParameterHandler.
+     */
+    public ParameterHandler getParameterHandler()
+    {
+        if ( handler == null)
+        {
+            throw new PVTSystemException( "Null parameter handler" );
+        }
+        return handler;
+    }
+
+    /**
+     * Apply a set of filters to a validator
+     * // TODO : Define api here.
+     * @param filtering
+     */
+    public abstract boolean filter (T... filtering);
+
+    public abstract void initialiseFilter (String[] filters);
+}

--- a/harness/src/test/java/org/jboss/pvt/harness/ClassVersionInspectorTest.java
+++ b/harness/src/test/java/org/jboss/pvt/harness/ClassVersionInspectorTest.java
@@ -1,6 +1,9 @@
 package org.jboss.pvt.harness;
 
 import org.apache.commons.io.FileUtils;
+import org.jboss.pvt.harness.exception.PVTException;
+import org.jboss.pvt.harness.utils.ClassVersion;
+import org.jboss.pvt.harness.utils.ClassVersionInspector;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -21,22 +24,22 @@ public class ClassVersionInspectorTest
 
 
     @Test
-    public void checkClassVersionTest()
+    public void checkClassVersionTest() throws PVTException
     {
         String classFileName = ClassVersionInspector.class.getCanonicalName().replace( ".", "/" ) + ".class";
         File classFile = new File( ClassVersionInspector.class.getClassLoader().getResource( classFileName).getFile() );
 
         assertTrue( classFile.exists() );
         assertTrue( ClassVersionInspector.checkClassVersion( classFile.toString() ).equals(
-                        ClassVersionInspector.ClassVersion.JAVA_18 ) );
+                        ClassVersion.JAVA_18 ) );
     }
 
     @Test
-    public void checkJarVersionTest() throws IOException
+    public void checkJarVersionTest() throws IOException, PVTException
     {
         File target = tf.newFile();
         FileUtils.copyURLToFile( new URL( "http://central.maven.org/maven2/commons-test/commons/test-0.1/commons-test-0.1.jar"), target);
 
-        assertTrue( ClassVersionInspector.checkJarVersion( target.toString(), ClassVersionInspector.ClassVersion.JAVA_14 ) );
+        assertTrue( ClassVersionInspector.checkJarVersion( target.toString(), ClassVersion.JAVA_14 ) );
     }
 }


### PR DESCRIPTION
@ryanzhang  @yongyang  A possible approach to use a more standardised api for the validators which the tests then use. API for populating filtering data (which should probably come from configuration) is not yet defined 