### PR TITLE
Update the default name and directory of the report and add in a -Dre…

### DIFF
--- a/harness/src/main/java/org/jboss/pvt/harness/reporting/Reporter.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/reporting/Reporter.java
@@ -17,10 +17,17 @@ import java.util.Date;
 public abstract class Reporter {
 
     public static final String DEFAULT_TEMPLATE = "/report.template.html";
-    public static final String DEFAULT_OUTPUT_PATH = "pvt_report_%{product}_%{version}_%{date}.html";
+    public static final String DEFAULT_OUTPUT_PATH = "../target/pvt_report_%{product}_%{version}.html";
+    public static final String DEFAULT_OUTPUT_DIRECTORY = "../target";
+    public static final String DEFAULT_OUTPUT_NAME = "/pvt_report_%{product}_%{version}.html";
+    public static final String OUTPUT_ENDING = ".html";
+
 
     public static final String DEFAULT_HANDOVER_SUMMARY_TEMPLATE = "/handover-summary.adoc";
-    public static final String DEFAULT_HANDOVER_SUMMARY_OUTPUT_PATH = "pvt_handover_summary_%{product}_%{version}_%{date}.adoc";
+    public static final String DEFAULT_HANDOVER_SUMMARY_OUTPUT_PATH = "../target/pvt_handover_summary_%{product}_%{version}.adoc";
+    public static final String DEFAULT_HANDOVER_SUMMARY_OUTPUT_DIRETORY = "../target";
+    public static final String DEFAUL_HANDOVER_SUMMARY_OUTPUT_NAME = "/pvt_report_%{product}_%{version}.adoc";
+    public static final String HANDOVER_SUMMARY_OUTPUT_ENDING = ".adoc";
 
     private String outFile;
 
@@ -40,27 +47,17 @@ public abstract class Reporter {
         this.outFile = outFile;
     }
 
-    public String getOutFile(Report report) {
-        String out = outFile.replace("%{product}", report.getConfiguration().getProduct())
-                .replace("%{version}",report.getConfiguration().getVersion())
-                .replace("%{target}",report.getConfiguration().getTarget())
-                .replace("%{date}", new SimpleDateFormat("yyMMdd").format(new Date()));
-        return out;
-    }
 
-    public void render(Report report) throws Exception{
-        String file = getOutFile(report);
-        logger.info("Generating report to " + file);
-        render(report,DEFAULT_TEMPLATE, new File(file));
-    }
-
-    public void renderHandoverSummary(Report report) throws Exception{
-        String out = DEFAULT_HANDOVER_SUMMARY_OUTPUT_PATH.replace("%{product}", report.getConfiguration().getProduct())
-                .replace("%{version}",report.getConfiguration().getVersion())
-                .replace("%{target}",report.getConfiguration().getTarget())
-                .replace("%{date}", new SimpleDateFormat("yyMMdd").format(new Date()));
-        logger.info("Generating handover summary doc to " + out);
-        render(report, DEFAULT_HANDOVER_SUMMARY_TEMPLATE, new File(out));
+    public void render(Report report, String location) throws Exception{
+        
+        String out_html = location.concat(OUTPUT_ENDING);
+        logger.info("Generating report to " + out_html);
+        render(report,DEFAULT_TEMPLATE, new File(out_html));
+       
+        String out_adoc = location.concat(HANDOVER_SUMMARY_OUTPUT_ENDING);
+        logger.info("Generating handover summary doc to " + out_adoc);
+        render(report, DEFAULT_HANDOVER_SUMMARY_TEMPLATE, new File(out_adoc));
+        
     }
 
     public abstract void render(Report report, String templateFile,File outFile) throws Exception;


### PR DESCRIPTION
PBRPMS-2295 part2
Update the default name and directory of the report and add in a -Dreport.filepath option to allow users to change the name and output directory
For example -Dreport.filepath=/home/user/Desktop/test 
will generate two reports test.html and test.adoc on Desktop
