### PR TITLE
Fix IPBRPMS-2731: PVT can't test the -add-ons.zip since there are zip files inside -add-ons.zip

### DIFF
--- a/harness/src/main/java/org/jboss/pvt/harness/utils/ResourceUtils.java
+++ b/harness/src/main/java/org/jboss/pvt/harness/utils/ResourceUtils.java
@@ -25,6 +25,8 @@ import org.zeroturnaround.zip.ZipUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
+import java.util.HashSet;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
@@ -111,7 +113,6 @@ public class ResourceUtils
                     {
                         logger.info( "Copying URL {} to {}", zip, result );
                         org.apache.commons.io.FileUtils.copyURLToFile( new URL( zip ), result );
-                        ZipUtil.explode( result );
                     }
                 }
                 // Local file path
@@ -126,9 +127,25 @@ public class ResourceUtils
                     else
                     {
                         org.apache.commons.io.FileUtils.copyFile( new File( zip ), result );
-                        ZipUtil.explode( result );
                     }
                 }
+
+                Collection<File> zipFiles;
+                if (result.isFile()) {
+                    zipFiles = new HashSet<>();
+                    zipFiles.add(result);
+                } else {
+                    zipFiles = DirUtils.listFilesRecursively(result,  pathname -> pathname.isFile() && pathname.getName().endsWith(".zip"));
+                }
+                while(!zipFiles.isEmpty()) {
+                    // Unzip them all
+                    for (File zipFile : zipFiles) {
+                        ZipUtil.explode(zipFile);
+                    }
+                    // Update zip files list and set for next recursion
+                    zipFiles = DirUtils.listFilesRecursively(result, pathname -> pathname.isFile() && pathname.getName().endsWith(".zip"));
+                }
+
                 logger.debug( "Create distribution {} ", result );
             }
         }


### PR DESCRIPTION
When unpacking zips, use a file list to track whthere there is any zip exists. Beginning with the downloadresult, unpack all the zips in the file list and update the list until there is no more zips.